### PR TITLE
Fix token aware policy

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2254,7 +2254,7 @@ func TestDiscoverViaProxy(t *testing.T) {
 	// This (complicated) test tests that when the driver is given an initial host
 	// that is infact a proxy it discovers the rest of the ring behind the proxy
 	// and does not store the proxies address as a host in its connection pool.
-	// See https://github.com/gocql/gocql/issues/481
+	// See https://github.com/i/gocql/issues/481
 	proxy, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("unable to create proxy listener: %v", err)

--- a/conn.go
+++ b/conn.go
@@ -21,9 +21,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/i/gocql/internal/lru"
 
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/i/gocql/internal/streams"
 )
 
 var (

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/i/gocql/internal/ccm"
 )
 
 func TestEventDiscovery(t *testing.T) {

--- a/marshal.go
+++ b/marshal.go
@@ -1094,7 +1094,6 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	case *time.Time:
 		if len(data) == 0 {
-			*v = time.Time{}
 			return nil
 		}
 		x := decBigInt(data)

--- a/metadata.go
+++ b/metadata.go
@@ -508,10 +508,7 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 			columnfamily_name,
 			key_validator,
 			comparator,
-			default_validator,
-			key_aliases,
-			column_aliases,
-			value_alias
+			default_validator
 		FROM system.schema_columnfamilies
 		WHERE keyspace_name = ?`
 
@@ -521,9 +518,6 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 				&table.KeyValidator,
 				&table.Comparator,
 				&table.DefaultValidator,
-				&keyAliasesJSON,
-				&columnAliasesJSON,
-				&table.ValueAlias,
 			)
 		}
 	} else {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/i/gocql/internal/lru"
 	"sync"
 )
 

--- a/session.go
+++ b/session.go
@@ -19,7 +19,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/i/gocql/internal/lru"
 )
 
 // Session is the interface used by users to interact with the database.
@@ -893,7 +893,7 @@ func (q *Query) PageState(state []byte) *Query {
 // CAS operations which do not end in Cas.
 //
 // See https://issues.apache.org/jira/browse/CASSANDRA-11099
-// https://github.com/gocql/gocql/issues/612
+// https://github.com/i/gocql/issues/612
 func (q *Query) NoSkipMetadata() *Query {
 	q.disableSkipMetadata = true
 	return q
@@ -1559,7 +1559,7 @@ var (
 	ErrUnavailable   = errors.New("unavailable")
 	ErrUnsupported   = errors.New("feature not supported")
 	ErrTooManyStmts  = errors.New("too many statements")
-	ErrUseStmt       = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
+	ErrUseStmt       = errors.New("use statements aren't supported. Please see https://github.com/i/gocql for explaination.")
 	ErrSessionClosed = errors.New("session has been closed")
 	ErrNoConnections = errors.New("gocql: no hosts available in the pool")
 	ErrNoKeyspace    = errors.New("no keyspace provided")

--- a/token.go
+++ b/token.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gocql/gocql/internal/murmur"
+	"github.com/i/gocql/internal/murmur"
 )
 
 // a token partitioner


### PR DESCRIPTION
The following fields don't exist on 2.1 `system.schema_columnfamilies` table:

* key_aliases
* column_aliases
* value_alias